### PR TITLE
harden metadata handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,10 +246,10 @@ runs:
         # write it to a temp file via heredoc so embedded quotes/newlines cannot
         # break shell parsing.
         if [ -z "$metadata_file" ] || [ ! -f "$metadata_file" ]; then
-          metadata_file="$(mktemp)"
-          cat <<'EOF' > "$metadata_file"
-${{ steps.docker-build-push-action.outputs.metadata }}
-EOF
+        metadata_file="$(mktemp)"
+        cat <<'EOF' > "$metadata_file"
+        ${{ steps.docker-build-push-action.outputs.metadata }}
+        EOF
         fi
 
         metadata=$(jq -c . "$metadata_file")

--- a/action.yml
+++ b/action.yml
@@ -241,13 +241,18 @@ runs:
 
         # Prefer the metadata file emitted by docker/build-push-action (avoids shell quoting pitfalls).
         metadata_file="${{ steps.docker-build-push-action.outputs.metadata-file }}"
-        if [ -n "$metadata_file" ] && [ -f "$metadata_file" ]; then
-          metadata=$(jq -c . "$metadata_file")
-        else
-          # Fallback to the raw metadata output; read from the action output safely.
-          metadata_raw="${{ steps.docker-build-push-action.outputs.metadata }}"
-          metadata=$(printf '%s' "$metadata_raw" | jq -c .)
+
+        # Some buildx versions omit metadata-file; fall back to the raw output, but
+        # write it to a temp file via heredoc so embedded quotes/newlines cannot
+        # break shell parsing.
+        if [ -z "$metadata_file" ] || [ ! -f "$metadata_file" ]; then
+          metadata_file="$(mktemp)"
+          cat <<'EOF' > "$metadata_file"
+${{ steps.docker-build-push-action.outputs.metadata }}
+EOF
         fi
+
+        metadata=$(jq -c . "$metadata_file")
 
         echo "metadata=$metadata" >> "$GITHUB_OUTPUT"
         echo "## Docker Image Metadata" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
 Fixed the CI parse error by hardening metadata handling in `../github-action-docker-build-push/action.yml`. The step now writes the buildx metadata output to a temp file via a heredoc when metadata-file is absent, then feeds that file to jq, so embedded quotes/newlines no longer break the shell.

This change removes the unsafe inline `"${{ steps.docker-build-push-action.outputs.metadata }}"` usage that produced the unexpected EOF while looking for matching "\" failure seen in connect-mfe-backend PRs in CI.

Context:
  - In `../github-action-docker-build-push/action.yml`, the “Get Metadata” step
    embedded `${{ steps.docker-build-push-action.outputs.metadata }}` directly
    into a Bash script. When that JSON contained quotes, it broke the script and
    produced an unexpected EOF while looking for matching "\" error.
  - The workflow itself never touches that JSON; it only invokes the action. So
    the fix belongs in the action.