### PR TITLE
Add ECR throttle-aware retry to push step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,31 +211,143 @@ runs:
         password: ${{ inputs.password }}
 
 
-    - name: Build and push Docker images
-      # Do not update to >=v6 untill the issue would be solved
-      # https://github.com/docker/build-push-action/issues/1167
-      uses: docker/build-push-action@v5
+    # Replaces docker/build-push-action@v5 with a direct `docker buildx build --push`
+    # invocation wrapped in a throttle-aware retry loop. ECR's PutImage TPS limits
+    # cause "toomanyrequests: Rate exceeded" failures when many matrix jobs push
+    # simultaneously; this loop detects only those errors (not real build failures)
+    # and retries with exponential backoff + jitter to avoid thundering-herd retries.
+    #
+    # Inputs are passed via env: rather than inline ${{ }} expansion to prevent shell
+    # injection from arbitrary user-supplied values (tags, labels, build-args, etc.).
+    - name: Build and push Docker images (throttle-aware retry)
       id: docker-build-push-action
-      with:
-        allow: ${{ inputs.allow }}
-        network: ${{ inputs.network }}
-        context: ${{ inputs.workdir }}
-        file: ${{ inputs.workdir }}/${{ inputs.file }}
-        pull: true
-        push: true
-        ssh: ${{ inputs.ssh }}
-        build-args: ${{ inputs.build-args }}
-        build-contexts: ${{ inputs.build-contexts }}
-        cache-from: ${{ inputs.cache-from }}
-        cache-to: ${{ inputs.cache-to }}
-        no-cache: ${{ inputs.no-cache }}
-        tags: ${{ steps.meta.outputs.tags }}
-        target: ${{ inputs.target }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: ${{ inputs.platforms }}
-        provenance: ${{ inputs.provenance }}
-        secrets: ${{ inputs.secrets }}
-        secret-files: ${{ inputs.secret-files }}
+      shell: bash
+      env:
+        IN_ALLOW: ${{ inputs.allow }}
+        IN_NETWORK: ${{ inputs.network }}
+        IN_WORKDIR: ${{ inputs.workdir }}
+        IN_FILE: ${{ inputs.file }}
+        IN_SSH: ${{ inputs.ssh }}
+        IN_BUILD_ARGS: ${{ inputs.build-args }}
+        IN_BUILD_CONTEXTS: ${{ inputs.build-contexts }}
+        IN_CACHE_FROM: ${{ inputs.cache-from }}
+        IN_CACHE_TO: ${{ inputs.cache-to }}
+        IN_NO_CACHE: ${{ inputs.no-cache }}
+        IN_TAGS: ${{ steps.meta.outputs.tags }}
+        IN_TARGET: ${{ inputs.target }}
+        IN_LABELS: ${{ steps.meta.outputs.labels }}
+        IN_PLATFORMS: ${{ inputs.platforms }}
+        IN_PROVENANCE: ${{ inputs.provenance }}
+        IN_SECRETS: ${{ inputs.secrets }}
+        IN_SECRET_FILES: ${{ inputs.secret-files }}
+      run: |
+        set -uo pipefail
+
+        metadata_file="$(mktemp -t buildx-metadata.XXXXXX.json)"
+        args=(buildx build --pull --push --metadata-file "$metadata_file")
+
+        # Append `--flag VALUE` for each non-empty newline-delimited entry.
+        add_repeated() {
+          local flag="$1" value="$2"
+          [ -z "$value" ] && return 0
+          while IFS= read -r line; do
+            [ -n "$line" ] && args+=("$flag" "$line")
+          done <<< "$value"
+        }
+
+        # Append `--flag VALUE` if value is non-empty.
+        add_single() {
+          local flag="$1" value="$2"
+          [ -n "$value" ] && args+=("$flag" "$value")
+        }
+
+        add_repeated --allow         "$IN_ALLOW"
+        add_single   --network       "$IN_NETWORK"
+        add_single   --file          "$IN_WORKDIR/$IN_FILE"
+        add_single   --ssh           "$IN_SSH"
+        add_repeated --build-arg     "$IN_BUILD_ARGS"
+        add_repeated --build-context "$IN_BUILD_CONTEXTS"
+        add_repeated --cache-from    "$IN_CACHE_FROM"
+        add_repeated --cache-to      "$IN_CACHE_TO"
+        [ "$IN_NO_CACHE" = "true" ] && args+=(--no-cache)
+        add_repeated --tag           "$IN_TAGS"
+        add_single   --target        "$IN_TARGET"
+        add_repeated --label         "$IN_LABELS"
+        add_single   --platform      "$IN_PLATFORMS"
+        # provenance uses --flag=VALUE form so `false` is parsed as a boolean.
+        [ -n "$IN_PROVENANCE" ] && args+=("--provenance=$IN_PROVENANCE")
+
+        # Secrets: each `KEY=VALUE` line becomes an env-backed buildkit secret
+        # (kept out of process args / docker history). Multi-line secret values
+        # are not supported here; use secret-files for those.
+        if [ -n "$IN_SECRETS" ]; then
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            key="${line%%=*}"
+            value="${line#*=}"
+            envname="BUILDX_SECRET_${key}"
+            export "$envname=$value"
+            args+=(--secret "id=${key},env=${envname}")
+          done <<< "$IN_SECRETS"
+        fi
+
+        if [ -n "$IN_SECRET_FILES" ]; then
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            key="${line%%=*}"
+            path="${line#*=}"
+            args+=(--secret "id=${key},src=${path}")
+          done <<< "$IN_SECRET_FILES"
+        fi
+
+        args+=("$IN_WORKDIR")
+
+        max_attempts=4
+        base_delay=15
+        attempt=1
+
+        while : ; do
+          log="$(mktemp)"
+          echo "::group::buildx attempt ${attempt}/${max_attempts}"
+          docker "${args[@]}" 2>&1 | tee "$log"
+          rc=${PIPESTATUS[0]}
+          echo "::endgroup::"
+
+          if [ "$rc" -eq 0 ]; then
+            break
+          fi
+
+          # Only retry registry throttling. Real build errors fail fast.
+          if ! grep -qiE "toomanyrequests|rate exceeded|throttl" "$log"; then
+            echo "::error::buildx failed (rc=$rc); error is not a registry throttle, not retrying."
+            exit "$rc"
+          fi
+
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "::error::ECR throttling persisted after ${max_attempts} attempts."
+            exit "$rc"
+          fi
+
+          # Exponential backoff (15s, 30s, 60s, ...) plus 0-29s jitter to
+          # desynchronize concurrent matrix-job retries.
+          delay=$(( base_delay * (2 ** (attempt - 1)) ))
+          jitter=$(( RANDOM % 30 ))
+          total=$(( delay + jitter ))
+          echo "::warning::ECR throttled — sleeping ${total}s before retry $((attempt + 1))/${max_attempts}."
+          sleep "$total"
+          attempt=$(( attempt + 1 ))
+        done
+
+        # Emit the same outputs docker/build-push-action would have, so the
+        # downstream "Get Metadata" step (which keys off this step's id) is
+        # unaffected.
+        echo "metadata-file=$metadata_file" >> "$GITHUB_OUTPUT"
+        {
+          echo 'metadata<<BUILDX_METADATA_EOF'
+          cat "$metadata_file"
+          echo
+          echo 'BUILDX_METADATA_EOF'
+        } >> "$GITHUB_OUTPUT"
 
     - name: Get Metadata
       id: get-metadata


### PR DESCRIPTION
## Summary

Replaces the `docker/build-push-action@v5` step with a direct `docker buildx build --push` invocation wrapped in a throttle-aware retry loop. ECR rejects manifest pushes with `toomanyrequests: Rate exceeded` when many CI matrix jobs push concurrently; this change retries those (and only those) failures with exponential backoff + jitter.

## Why

The forge monorepo's PR CI fans out to ~23 service images in parallel via `ci-dockerized-app-build.yml`. Each build pushes the same digest under three tags (`sha-FULL`, `pr-NUM`, `sha-short`), so on a busy PR roughly 70 manifest writes hit ECR within seconds — well past the per-region `PutImage` TPS limit.

Recent failure (PR #16434, `aetna-accumulator` build):

```
#22 pushing manifest for ***/smithhealth/aetna-accumulator:sha-a17e266@sha256:356f6cdbc863fb930983522dd9875fa513e872e1a5ab8bff9e22c7ba25908985 0.2s done
#22 ERROR: failed to push ***/smithhealth/aetna-accumulator:sha-a17e266: toomanyrequests: Rate exceeded
```

Two layers of layered indirection are involved:

1. forge's `pull-request.yml` → calls `SmithHealth/github-actions-workflows/.github/workflows/ci-dockerized-app-build.yml@main`
2. that reusable workflow → calls `SmithHealth/github-action-docker-build-push@main` (this repo)
3. this action → called `docker/build-push-action@v5` (the step that emitted the throttle error)

Wrapping at any of the outer layers either retries on every failure (wasteful on real build breaks) or can't selectively retry at all because GitHub Actions retry helpers don't wrap `uses:` steps. Doing it here, at the lowest layer, is the principled fix: we own the shell invocation and can grep the log for throttle markers.

## What changed

- Replaces the `docker/build-push-action@v5` step with a `shell: bash` step that calls `docker buildx build --pull --push` directly.
- Wraps the call in a loop with up to **4 attempts**, **exponential backoff** (15s, 30s, 60s) and **0–29s jitter** to desynchronize concurrent matrix-job retries (avoids thundering-herd re-throttling).
- **Only retries** when the build log contains `toomanyrequests`, `rate exceeded`, or `throttl`. Real failures (compile errors, missing files, auth) fail fast on attempt #1, so broken PRs don't waste 4× the runner time.
- Caller-supplied inputs (`tags`, `labels`, `build-args`, `secrets`, `cache-from`, `cache-to`, etc.) are routed through `env:` rather than inline `${{ }}` interpolation, so this step adds no shell-injection surface.
- Step id (`docker-build-push-action`) and outputs (`metadata`, `metadata-file`) are preserved so the downstream `Get Metadata` step is unaffected.

## Risk surface

- **Functional behavior:** Should be a no-op on the happy path. `docker buildx build --push` is the same command `docker/build-push-action` runs internally; we just call it explicitly so we can wrap retries around it.
- **Inputs not supported by the new step:** none — `allow`, `network`, `ssh`, `build-args`, `build-contexts`, `cache-from`, `cache-to`, `no-cache`, `tags`, `target`, `labels`, `platforms`, `provenance`, `secrets`, `secret-files` all plumbed through.
- **Secrets:** `secrets` input values pass via `env` and are exposed to BuildKit with `--secret id=KEY,env=BUILDX_SECRET_KEY`, keeping them out of process args / `docker history` (same posture as `docker/build-push-action`).
- **Metadata output:** still emitted via `--metadata-file` and re-exposed as `outputs.metadata` and `outputs.metadata-file`, matching what `docker/build-push-action` set.

## Test plan

- [ ] Push branch and reference it from a forge PR via `SmithHealth/github-actions-workflows` pinned to a test branch that points this action at `@ecr-throttle-aware-retry-on-push`.
- [ ] Confirm a normal PR build completes on attempt 1 (look for the `::group::buildx attempt 1/4` line in the log).
- [ ] Force a real build failure (e.g., bad Dockerfile syntax) and confirm the step exits without retrying.
- [ ] Optionally simulate throttling by exercising a high-fan-out PR; confirm any throttled job retries with the `::warning::ECR throttled` message and ultimately succeeds.

## Out of scope (separate follow-up)

The Semgrep scan flagged three pre-existing issues in `action.yml` unrelated to this change. Filing separately:

- `Set image name` step interpolates `${{ inputs.* }}` into a `run:` block (CWE-78).
- `Docker Inspect` step has a broken conditional `if:  ${{ inputs.inspect }} == 'true'` that always evaluates truthy — the step has been running on every invocation.
- `Docker Inspect` step interpolates `${{ inputs.* }}` and `${{ steps.*.outputs.* }}` into a `run:` block (CWE-78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
